### PR TITLE
support for resque-scheduler

### DIFF
--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -39,6 +39,10 @@
   <% end %>
 </table>
 
+<% unless @statuses.empty? %>
+	<%= partial :next_more, :start => @start, :size => @size %>
+<% end %>
+
 <%= poll %>
 
 <script type="text/javascript" charset="utf-8">

--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -8,7 +8,10 @@ module Resque
     def self.registered(app)
       
       app.get '/statuses' do
-        @statuses = Resque::Status.statuses
+        @start = params[:start].to_i
+        @end = @start + (params[:per_page] || 50)
+        @statuses = Resque::Status.statuses(@start, @end)
+        @size = @statuses.size
         status_view(:statuses)
       end
       

--- a/test/test_resque-status.rb
+++ b/test/test_resque-status.rb
@@ -87,8 +87,21 @@ class TestResqueStatus < Test::Unit::TestCase
     end
     
     context ".status_ids" do
+      
+      setup do
+        @uuids = []
+        30.times{ Resque::Status.create }
+      end
+    
       should "return an array of job ids" do
         assert Resque::Status.status_ids.is_a?(Array)
+        assert_equal 32, Resque::Status.status_ids.size # 30 + 2
+      end
+      
+      should "let you paginate through the statuses" do
+        assert_equal Resque::Status.status_ids.reverse[0, 10], Resque::Status.status_ids(0, 10)
+        assert_equal Resque::Status.status_ids.reverse[9, 10], Resque::Status.status_ids(10, 20)
+        # assert_equal Resque::Status.status_ids.reverse[0, 10], Resque::Status.status_ids(0, 10)
       end
     end
     
@@ -101,6 +114,16 @@ class TestResqueStatus < Test::Unit::TestCase
       end
       
     end
+    
+    # context ".count" do
+    #   
+    #   should "return a count of statuses" do
+    #     statuses = Resque::Status.statuses
+    #     assert_equal 2, statuses.size
+    #     assert_equal statuses.size, Resque::Status.count
+    #   end
+    #   
+    # end
     
     context ".logger" do
       setup do


### PR DESCRIPTION
Here is a simple patch so resque scheduler and resque status can work together happily, see http://github.com/bvandenbos/resque-scheduler (readme notes) for more info.
