### PR TITLE
Allow perform to be called without a uuid (it will then create its own)

### DIFF
--- a/lib/resque/job_with_status.rb
+++ b/lib/resque/job_with_status.rb
@@ -82,7 +82,8 @@ module Resque
     # options.
     #
     # You should not override this method, rahter the <tt>perform</tt> instance method.
-    def self.perform(uuid, options = {})
+    def self.perform(uuid=nil, options = {})
+      uuid ||= Resque::Status.generate_uuid
       instance = new(uuid, options)
       instance.safe_perform!
       instance


### PR DESCRIPTION
Hey there,

Our team is working on integrating resque-status with resque-scheduler for our interval based jobs. Thanks to the "scheduled" API, we're able to do this just fine on the servers that actually perform the work. Those hosts have the worker classes loaded and are able to call ClassName.scheduled().

We've made the decision to not load the full tech stack with all of the worker classes on the web hosts, however. As a result, when resque-scheduler's web interface is used to queue up a job immediately (via /schedule/requeue), the web interface is unable to call ClassName.scheduled() because it is unable to constantize "ClassName" in the first place.

After exploring several different options and running them by matteti, our team has decided that the best way to allow us to use the resque-scheduler web interface without having Resque::JobWithStatus and all of the worker classes loaded is to simply enqueue the jobs without having them be full fledged jobs with statuses. We'll miss out on seeing the status for the job, but we do have the benefits of maintaining a small footprint while retaining the resque-scheduler requeue functionality.

resque-scheduler can queue up a Resque::JobWithStatus based job easily enough with Resque::Job.create(queue, class_name, *params). Unfortunately, resque then ends up calling perform() without a uuid. We're fine with this (because we know it's not a full fledged job with a status), but unfortunately the uuid is a required argument.

This pull request makes the uuid argument of the perform() method optional, but still ensures that a uuid is created and passed downstream after perform() is called. It's necessary for us to get resque-scheduler and resque-status to play nicely with each other in the way that we want them to (no worker classes loaded on the web side of things) and we'd love to have this logic merged so that we don't have to override perform().

Thanks very much for your time.
