### PR TITLE
Pagination broke live polling

### DIFF
--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -43,7 +43,7 @@
 	<%= partial :next_more, :start => @start, :size => @size %>
 <% end %>
 
-<%= poll %>
+<%= status_poll(@start) %>
 
 <script type="text/javascript" charset="utf-8">
   jQuery(function($) {

--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -40,13 +40,26 @@ module Resque
         content_type "text/plain"
         @polling = true
 
-        @statuses = Resque::Status.statuses
+        @start = params[:start].to_i
+        @end = @start + (params[:per_page] || 50)
+        @statuses = Resque::Status.statuses(@start, @end)
+        @size = @statuses.size
+
         status_view(:statuses, {:layout => false})
       end
       
       app.helpers do
         def status_view(filename, options = {}, locals = {})
           erb(File.read(File.join(::Resque::StatusServer::VIEW_PATH, "#{filename}.erb")), options, locals)
+        end
+
+        def status_poll(start)
+          if @polling
+            text = "Last Updated: #{Time.now.strftime("%H:%M:%S")}"
+          else
+            text = "<a href='#{url(request.path_info)}.poll?start=#{start}' rel='poll'>Live Poll</a>"
+          end
+          "<p class='poll'>#{text}</p>"
         end
       end
       


### PR DESCRIPTION
Here is an (admittedly not nice) patch for the broken live polling since the pagination commit 6e1bf0cd85eeae3faac12338b0ed16ab78e7c3d0.

I'd rather not have copied "poll" but I can't see any other way around this.

Note that once polling is started "next" and "previous" links will break due to "current_page" usage in "next_more.erb" (resque-web) template.

Sorry I didn't add any tests, hoping you'll shape this up! :)
-fotos
