### PR TITLE
Pagination pull request

### DIFF
--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -11,7 +11,7 @@ module Resque
         @start = params[:start].to_i
         @end = @start + 20
         @statuses = Resque::Status.statuses(@start, @end)
-        @size = @statuses.size
+        @size = Resque::Status.count
         status_view(:statuses)
       end
       
@@ -43,7 +43,7 @@ module Resque
         @start = params[:start].to_i
         @end = @start + 20
         @statuses = Resque::Status.statuses(@start, @end)
-        @size = @statuses.size
+        @size = Resque::Status.count
 
         status_view(:statuses, {:layout => false})
       end


### PR DESCRIPTION
A couple quick changes to make pagination match the more_next helper being called from Resque.  The @size one is likely more important as it makes it possible to never be able to get to some statuses via pagination links.  To them 'size' isn't the size of the page, but the total number of elements to be paginated across.  
