### PR TITLE
Resque 1.15.0 compatibility

### DIFF
--- a/lib/resque/server/views/status.erb
+++ b/lib/resque/server/views/status.erb
@@ -1,7 +1,7 @@
 <%= status_view :status_styles, :layout => false %>
 
 <h1 class='wi'>Statuses: <%= @status.uuid %>/<%= @status.name %></h1>
-<p class='intro'>Viewing a specific job created with JobWithStatus. <a href="<%= url(:statuses) %>">Return to the list of statuses</a></p>
+<p class='intro'>Viewing a specific job created with JobWithStatus. <a href="<%= u(:statuses) %>">Return to the list of statuses</a></p>
 
 <div class="status-holder" rel="<%= @status.status %>" id="status_<%= @status.uuid %>">
   <div class="status-progress">
@@ -22,7 +22,7 @@
 
     function checkStatus($status) {
       var status_id = $status.attr('id').replace('status_', '');
-      $.getJSON('<%= url(:statuses) %>/' + status_id + '.js', function(json) {
+      $.getJSON('<%= u(:statuses) %>/' + status_id + '.js', function(json) {
         if (json) {
           var pct = "0%";
           if (json.pct_complete) {

--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -2,7 +2,7 @@
 
 <h1 class='wi'>Statuses</h1>
 <%unless @statuses.empty?%>
-  <form method="POST" action="<%= url(:statuses) %>/clear" class='clear-failed'>
+  <form method="POST" action="<%= u(:statuses) %>/clear" class='clear-failed'>
   <input type='submit' name='' value='Clear Statuses' />
 </form>
 <%end%>
@@ -20,7 +20,7 @@
   <% unless @statuses.empty? %>
     <% @statuses.each do |status| %>
     <tr>
-      <td><a href="<%= url(:statuses) %>/<%= status.uuid %>"><%= status.uuid %></a></td>
+      <td><a href="<%= u(:statuses) %>/<%= status.uuid %>"><%= status.uuid %></a></td>
       <td><%= status.name %></td>
       <td class="status status-<%= status.status %>"><%= status.status %></td>
       <td class="time"><%= status.time %></td>
@@ -29,7 +29,7 @@
         <div class="progress-pct"><%= status.pct_complete ? "#{status.pct_complete}%" : '' %></div>
       </td>
       <td><%= status.message %></td>
-      <td><% if status.killable? %><a href="<%= url(:statuses) %>/<%= status.uuid %>/kill" class="kill">Kill</a><% end %></td>
+      <td><% if status.killable? %><a href="<%= u(:statuses) %>/<%= status.uuid %>/kill" class="kill">Kill</a><% end %></td>
     </tr>
     <% end %>
   <% else %>  

--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -28,12 +28,12 @@ module Resque
       
       app.post '/statuses/:id/kill' do
         Resque::Status.kill(params[:id])
-        redirect url(:statuses)
+        redirect u(:statuses)
       end
       
       app.post '/statuses/clear' do
         Resque::Status.clear
-        redirect url(:statuses)
+        redirect u(:statuses)
       end
       
       app.get "/statuses.poll" do
@@ -57,7 +57,7 @@ module Resque
           if @polling
             text = "Last Updated: #{Time.now.strftime("%H:%M:%S")}"
           else
-            text = "<a href='#{url(request.path_info)}.poll?start=#{start}' rel='poll'>Live Poll</a>"
+            text = "<a href='#{u(request.path_info)}.poll?start=#{start}' rel='poll'>Live Poll</a>"
           end
           "<p class='poll'>#{text}</p>"
         end


### PR DESCRIPTION
Resque renamed their url method to url_path because of Sinatra. See defunkt/resque@b7d5dd621270ba937777ee0e909f1013f52001ba and defunkt/resque@65f7bb0c5ccd159e5059954cfdea292d6ff94cf0.

I believe these changes will fix this.

Many thanks,
Trevor
