### PR TITLE
Correct example code

### DIFF
--- a/examples/sleep_job.rb
+++ b/examples/sleep_job.rb
@@ -5,7 +5,7 @@ require 'resque/job_with_status' # in rails you would probably do this in an ini
 class SleepJob < Resque::JobWithStatus
   
   def perform
-    total = options['length'].to_i || 1000
+    total = options.has_key?('length') ? options['length'].to_i : 1000
     num = 0
     while num < total
       at(num, total, "At #{num} of #{total}")


### PR DESCRIPTION
Accessing a hash key that does not exist returns nil.  nil.to_i is 0.  So, the original version would set total to 0 when a length was not specified.  That would skip the while loop and the job would complete immediately.

This correction will set total to 1000 when options['length'] is nil as intended.
