### PR TITLE
Fix: 'Updated_at: "NaN days ago"' in worker status

### DIFF
--- a/lib/resque/status.rb
+++ b/lib/resque/status.rb
@@ -234,7 +234,7 @@ module Resque
     # Return the time of the status initialization. If set returns a <tt>Time</tt>
     # object, otherwise returns nil
     def time
-      time? ? Time.at(self['time']).strftime("%Y/%m/%d %H:%M:%S %Z") : nil
+      time? ? Time.at(self['time']).strftime("%Y/%m/%d %H:%M:%S %z") : nil
     end
 
     STATUSES.each do |status|


### PR DESCRIPTION
Please find a tiny changeset to fix the 'Updated_at: "NaN days ago' issue with relative dates once for all.

I know that pull #39 already tried to tackle that issue but it remains broken on my Firefox 8 / MSIE 9 with exotic timezone. The reason is that the above pull request uses `%Z` in its strftime format string where `%z` should have been used, resulting in dates that do not parse in Javascript at least on my configuration.

I reported a similar issue in defunkt/resque#475
