### PR TITLE
Statuses are added for jobs that fail before_enqueue hooks

### DIFF
--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -80,11 +80,17 @@ module Resque
         end
 
         # Adds a job of type <tt>klass<tt> to the queue with <tt>options<tt>.
-        # Returns the UUID of the job
+        #
+        # Returns the UUID of the job if the job was queued, or nil if the job was
+        # rejected by a before_enqueue hook.
         def enqueue(klass, options = {})
-          uuid = Resque::Plugins::Status::Hash.create :options => options
-          Resque.enqueue(klass, uuid, options)
-          uuid
+          uuid = Resque::Plugins::Status::Hash.generate_uuid
+          if Resque.enqueue(klass, uuid, options)
+            Resque::Plugins::Status::Hash.create uuid, :options => options
+            uuid
+          else
+            nil
+          end
         end
 
         # This is the method called by Resque::Worker when processing jobs. It

--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -11,8 +11,7 @@ module Resque
 
         # Create a status, generating a new UUID, passing the message to the status
         # Returns the UUID of the new status.
-        def self.create(*messages)
-          uuid = generate_uuid
+        def self.create(uuid, *messages)
           set(uuid, *messages)
           redis.zadd(set_key, Time.now.to_i, uuid)
           redis.zremrangebyscore(set_key, 0, Time.now.to_i - @expire_in) if @expire_in

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -98,3 +98,15 @@ class FailureJob
     failed("I'm such a failure")
   end
 end
+
+class NeverQueuedJob
+  include Resque::Plugins::Status
+
+  def self.before_enqueue(*args)
+    false
+  end
+
+  def perform
+    # will never get called
+  end
+end

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -32,6 +32,26 @@ class TestResquePluginsStatus < Test::Unit::TestCase
 
     end
 
+    context ".create with a failing before_enqueue hook" do
+      setup do
+        @size = Resque.size(:statused)
+        @status_ids_size = Resque::Plugins::Status::Hash.status_ids.length
+        @res = NeverQueuedJob.create(:num => 100)
+      end
+
+      should "return nil" do
+        assert_equal nil, @res
+      end
+
+      should "not create a status" do
+        assert_equal @size, Resque.size(:statused)
+      end
+
+      should "not add the uuid to the statuses" do
+        assert_equal @status_ids_size, Resque::Plugins::Status::Hash.status_ids.length
+      end
+    end
+
     context ".scheduled" do
       setup do
         @job_args = {'num' => 100}

--- a/test/test_resque_plugins_status_hash.rb
+++ b/test/test_resque_plugins_status_hash.rb
@@ -6,9 +6,9 @@ class TestResquePluginsStatusHash < Test::Unit::TestCase
     setup do
       Resque.redis.flushall
       Resque::Plugins::Status::Hash.expire_in = nil
-      @uuid = Resque::Plugins::Status::Hash.create
+      @uuid = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid)
       Resque::Plugins::Status::Hash.set(@uuid, "my status")
-      @uuid_with_json = Resque::Plugins::Status::Hash.create({"im" => "json"})
+      @uuid_with_json = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid, {"im" => "json"})
     end
 
     context ".get" do
@@ -43,17 +43,17 @@ class TestResquePluginsStatusHash < Test::Unit::TestCase
     context ".create" do
       should "add an item to a key set" do
         before = Resque::Plugins::Status::Hash.status_ids.length
-        Resque::Plugins::Status::Hash.create
+        Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid)
         after = Resque::Plugins::Status::Hash.status_ids.length
         assert_equal 1, after - before
       end
 
       should "return a uuid" do
-       assert_match(/^\w{32}$/, Resque::Plugins::Status::Hash.create)
+        assert_match(/^\w{32}$/, Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid))
       end
 
       should "store any status passed" do
-        uuid = Resque::Plugins::Status::Hash.create("initial status")
+        uuid = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid, "initial status")
         status = Resque::Plugins::Status::Hash.get(uuid)
         assert status.is_a?(Resque::Plugins::Status::Hash)
         assert_equal "initial status", status.message
@@ -61,17 +61,17 @@ class TestResquePluginsStatusHash < Test::Unit::TestCase
 
       should "expire keys if expire_in is set" do
         Resque::Plugins::Status::Hash.expire_in = 1
-        uuid = Resque::Plugins::Status::Hash.create("new status")
+        uuid = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid, "new status")
         assert_contains Resque::Plugins::Status::Hash.status_ids, uuid
         assert_equal "new status", Resque::Plugins::Status::Hash.get(uuid).message
         sleep 2
-        Resque::Plugins::Status::Hash.create
+        Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid)
         assert_does_not_contain Resque::Plugins::Status::Hash.status_ids, uuid
         assert_nil Resque::Plugins::Status::Hash.get(uuid)
       end
 
       should "store the options for the job created" do
-        uuid = Resque::Plugins::Status::Hash.create("new", :options => {'test' => '123'})
+        uuid = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid, "new", :options => {'test' => '123'})
         assert uuid
         status = Resque::Plugins::Status::Hash.get(uuid)
         assert status.is_a?(Resque::Plugins::Status::Hash)
@@ -98,7 +98,7 @@ class TestResquePluginsStatusHash < Test::Unit::TestCase
 
       setup do
         @uuids = []
-        30.times{ Resque::Plugins::Status::Hash.create }
+        30.times{ Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid) }
       end
 
       should "return an array of job ids" do


### PR DESCRIPTION
If a `before_enqueue` hook returns false, the job is not queued, but a status is created for it anyhow saying it is queued.

Fixed at https://github.com/kenpratt/resque-status/tree/before-enqueue-hooks-compatibility
