### PR TITLE
Added output of options on status details page

### DIFF
--- a/lib/resque/server/views/status.erb
+++ b/lib/resque/server/views/status.erb
@@ -10,6 +10,14 @@
   </div>
   <div class="status-message"><%= @status.message %></div>
   <div class="status-time"><%= @status.time? ? @status.time : 'Not started' %></div>
+  <div class="status-options">
+    <% if @status.options && @status.options.any? %>
+      <% @status.options.each do |k, v| %>
+        <div class="status-options-key"><%= k %></div>
+        <div class="status-options-value"><%= v %></div>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 
 <script type="text/javascript" charset="utf-8">

--- a/lib/resque/server/views/status_styles.erb
+++ b/lib/resque/server/views/status_styles.erb
@@ -91,6 +91,15 @@
   .status-killed {
     color: #B84F16;
   }
+  .status-options {
+  }
+  .status-options-key {
+    font-weight: bold;
+    margin-top: 1em;
+  }
+  .status-options-value {
+    margin-top: 0.25em;
+  }
   #main a.kill:link, #main a.kill:visited {
     color: #B84F16;
     font-weight: bold;


### PR DESCRIPTION
I have some jobs with a lot of stuff being passed into the options hash, so I overrode the `name` method in my subclasses to provide saner names for the Statuses. It's nice to still see the list of options, though, so I've added it to the status details page. Should be nice for people who don't override `name` as well, as they get a human-readable list of options as well as the `inspect` version in the title.
