### PR TITLE
Fix the "NaN days ago"  for "Last Updated" in /statuses page

### DIFF
--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -26,7 +26,7 @@
       <td><a href="<%= u(:statuses) %>/<%= status.uuid %>"><%= status.uuid %></a></td>
       <td><%= status.name %></td>
       <td class="status status-<%= status.status %>"><%= status.status %></td>
-      <td class="time"><%= status.time %></td>
+      <td class="time"><%= status.time.strftime("%Y/%m/%d %H:%M:%S %z") %></td>
       <td class="progress">
         <div class="progress-bar" style="width:<%= status.pct_complete %>%">&nbsp;</div>
         <div class="progress-pct"><%= status.pct_complete ? "#{status.pct_complete}%" : '' %></div>


### PR DESCRIPTION
At least in my environment (ruby 1.9.2) `Time.now.to_s` produces a string like: _2012-05-11 18:07:48 +0200_

In Safari this is not parsable with `new Date()`:

```
 > new Date('2012-05-11 18:07:48 +0200');
 > Invalid Date
```

In general the timestamp format of `Time.now.to_s` differs between ruby versions, so I think its best to  enforce a specific format that is known to work in all browser.
