### PR TITLE
Respect the queue name passed to Job#scheduled for resque-scheduler

### DIFF
--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -84,8 +84,16 @@ module Resque
         # Returns the UUID of the job if the job was queued, or nil if the job was
         # rejected by a before_enqueue hook.
         def enqueue(klass, options = {})
+          self.enqueue_to(Resque.queue_from_class(klass), klass, options)
+        end
+
+        # Adds a job of type <tt>klass<tt> to a specified queue with <tt>options<tt>.
+        #
+        # Returns the UUID of the job if the job was queued, or nil if the job was
+        # rejected by a before_enqueue hook.
+        def enqueue_to(queue, klass, options = {})
           uuid = Resque::Plugins::Status::Hash.generate_uuid
-          if Resque.enqueue(klass, uuid, options)
+          if Resque.enqueue_to(queue, klass, uuid, options)
             Resque::Plugins::Status::Hash.create uuid, :options => options
             uuid
           else
@@ -109,7 +117,7 @@ module Resque
         # This is needed to be used with resque scheduler
         # http://github.com/bvandenbos/resque-scheduler
         def scheduled(queue, klass, *args)
-          create(*args)
+          self.enqueue_to(queue, self, *args)
         end
       end
 

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -59,17 +59,23 @@ class TestResquePluginsStatus < Test::Unit::TestCase
       end
 
       should "create the job with the provided arguments" do
-
-        job = Resque.pop(:statused)
-
+        job = Resque.pop(:queue_name)
         assert_equal @job_args, job['args'].last
       end
     end
 
     context ".enqueue" do
-      setup do
+      should "delegate to enqueue_to, filling in the queue from the class" do
         @uuid = BasicJob.enqueue(WorkingJob, :num => 100)
         @payload = Resque.pop(:statused)
+        assert_equal "WorkingJob", @payload['class']
+      end
+    end
+
+    context ".enqueue_to" do
+      setup do
+        @uuid = BasicJob.enqueue_to(:new_queue, WorkingJob, :num => 100)
+        @payload = Resque.pop(:new_queue)
       end
 
       should "add the job with the specific class to the queue" do


### PR DESCRIPTION
There appears to be a bug when using resque-status with resque-scheduler that can cause jobs to be enqueued to the wrong queue.

This happens in the case where a developer defines the queue name not in the Job class itself (with a class variable or class method), but in a hash or yaml definition that is used to configure resque-scheduler. It appears that the resque-scheduler's README, where it talks about using resque-scheduler with resque-status, has an example like this, a case where the queue name would not be respected. From the resque-scheduler README:

SNIP

---

Let's pretend we have a JobWithStatus class called FakeLeaderboard

```
class FakeLeaderboard < Resque::JobWithStatus
  def perform
    # do something and keep track of the status
  end
end
```

And then a schedule:

```
create_fake_leaderboards:
  cron: "30 6 * * 1"
  queue: scoring
  custom_job_class: FakeLeaderboard
  args:
  rails_env: demo
  description: "This job will auto-create leaderboards for our online demo and the status will update as the worker makes progress"
```

If your extension doesn't support scheduled job, you would need to extend the
custom job class to support the #scheduled method:

```
module Resque
  class JobWithStatus
    # Wrapper API to forward a Resque::Job creation API call into
    # a JobWithStatus call.
    def self.scheduled(queue, klass, *args)
      create(*args)
    end
  end
end
```

---

END SNIP

In the above example, the actual queue that the job would be enqueud to is "statused", the default queue that Resque::JobWithStatus defines, and not "scoring" as the user would expect. You can see this is the case because the implementation of Job::scheduled above, taken from resque-status, does nothing with the queue name it is given. The disregard for the queue name makes me think for a second that it's intentional, but I can't think of why that would be.

This patch passes along the queue name that resque-scheduler passes in, so that the job is enqueued to the expected queue.
