### PR TITLE
Add button to clear only failed statuses to server plugin

### DIFF
--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -51,6 +51,14 @@ module Resque
           end
         end
         
+        def self.clear_failed(range_start = nil, range_end = nil)
+          status_ids(range_start, range_end).select do |id|
+            get(id).failed?
+          end.each do |id|
+            remove(id)
+          end
+        end
+        
         def self.remove(uuid)
           redis.del(status_key(uuid))
           redis.zrem(set_key, uuid)

--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -8,6 +8,9 @@
 <form method="POST" action="<%= u(:statuses) %>/clear/completed" class='clear-failed'>
   <input type='submit' name='' value='Clear Completed Statuses' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
 </form>
+<form method="POST" action="<%= u(:statuses) %>/clear/failed" class='clear-failed'>
+  <input type='submit' name='' value='Clear Failed Statuses' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+</form>
 <%end%>
 <p class='intro'>These are recent jobs created with the Resque::Plugins::Status class</p>
 <table>

--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -42,6 +42,11 @@ module Resque
         redirect u(:statuses)
       end
 
+      app.post '/statuses/clear/failed' do
+        Resque::Plugins::Status::Hash.clear_failed
+        redirect u(:statuses)
+      end
+
       app.get "/statuses.poll" do
         content_type "text/plain"
         @polling = true

--- a/test/test_resque_plugins_status_hash.rb
+++ b/test/test_resque_plugins_status_hash.rb
@@ -111,6 +111,23 @@ class TestResquePluginsStatusHash < Test::Unit::TestCase
       end
     end
     
+    context ".clear_failed" do
+      setup do
+        @failed_status_id = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid, {'status' => "failed"})
+        @not_failed_status_id = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid)
+        Resque::Plugins::Status::Hash.clear_failed
+      end
+      
+      should "clear failed status" do
+        assert_nil Resque::Plugins::Status::Hash.get(@failed_status_id)
+      end
+      
+      should "not clear not-failed status" do
+        status = Resque::Plugins::Status::Hash.get(@not_failed_status_id)
+        assert status.is_a?(Resque::Plugins::Status::Hash)
+      end
+    end
+    
     context ".remove" do
       setup do
         Resque::Plugins::Status::Hash.remove(@uuid)


### PR DESCRIPTION
If you have many jobs running, and you've taken care of the failed jobs (which may be high in number), but still want to see the statuses for running/queued jobs, clearing completed doesn't help, because the list is still polluted by failed jobs, and clearing all statuses is obviously not what you want to do.  This simple patch adds another button to clear failed statuses.
