### PR TITLE
Creating status hash before actually queuing job

### DIFF
--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -85,14 +85,15 @@ module Resque
         # rejected by a before_enqueue hook.
         def enqueue(klass, options = {})
           uuid = Resque::Plugins::Status::Hash.generate_uuid
+          Resque::Plugins::Status::Hash.create uuid, :options => options
+
           if Resque.enqueue(klass, uuid, options)
-            Resque::Plugins::Status::Hash.create uuid, :options => options
             uuid
           else
+            Resque::Plugins::Status::Hash.remove(uuid)
             nil
           end
         end
-
         # This is the method called by Resque::Worker when processing jobs. It
         # creates a new instance of the job class and populates it with the uuid and
         # options.


### PR DESCRIPTION
When using Resque.inline, for acceptance tests, jobs with status will run inline, as if Resque.enqueue was synchronous.

When the job finishes Resque::Plugins::Status.enqueue will create a new hash overriding the one that was used within the job (when calling #at, for example).

This will make the job status be reset to 'queued', though it has just completed.

By moving Resque::Plugins::Status::Hash.create before the Resque.enqueue, we make the status available to the job as usual, and we don't override the status set by the job. If Resque.enqueue fails we remove the created hash, thus ensuring that we won't leave an unused hash.

When Resque.inline is not used it works as usual.
