### PR TITLE
Add dequeue method.

### DIFF
--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -93,6 +93,15 @@ module Resque
           end
         end
 
+        # Removes a job of type <tt>klass<tt> from the queue.
+        #
+        # The initially given options are retrieved from the status hash.
+        # (Resque needs the options to find the correct queue entry)
+        def dequeue(klass, uuid)
+          status = Resque::Plugins::Status::Hash.get(uuid)
+          Resque.dequeue(klass, uuid, status.options)
+        end
+
         # This is the method called by Resque::Worker when processing jobs. It
         # creates a new instance of the job class and populates it with the uuid and
         # options.

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -90,6 +90,23 @@ class TestResquePluginsStatus < Test::Unit::TestCase
 
     end
 
+    context ".dequeue" do
+      setup do
+        @uuid1 = BasicJob.enqueue(WorkingJob, :num => 100)
+        @uuid2 = BasicJob.enqueue(WorkingJob, :num => 100)
+      end
+
+      should "dequeue the job with the uuid from the correct queue" do
+        size = Resque.size(:statused)
+        BasicJob.dequeue(WorkingJob, @uuid2)
+        assert_equal size-1, Resque.size(:statused)
+      end
+      should "not dequeue any jobs with different uuids for same class name" do
+        BasicJob.dequeue(WorkingJob, @uuid2)
+        assert_equal @uuid1, Resque.pop(:statused)['args'].first
+      end
+    end
+
     context ".perform" do
       setup do
         @uuid      = WorkingJob.create(:num => 100)


### PR DESCRIPTION
We tried to clean up several (dependant) jobs and therefore needed an option to remove jobs from the queue. Thanks for the nice status plugin!
