### PR TITLE
_statuses uuid should not removed when expired but the status:uuid key-value exists

### DIFF
--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -16,8 +16,19 @@ module Resque
         def self.create(uuid, *messages)
           set(uuid, *messages)
           redis.zadd(set_key, Time.now.to_i, uuid)
-          redis.zremrangebyscore(set_key, 0, Time.now.to_i - @expire_in) if @expire_in
+          remove_out_of_time_statuses(uuid)
           uuid
+        end
+
+        def self.remove_out_of_time_statuses(uuid)
+          if @expire_in
+            statuses = redis.zrange(set_key, 0, -1, :with_scores => true)
+            can_remove = []
+            statuses.each do |status|
+              can_remove << status[0] if status[0] && status[0] != uuid && redis.get(status_key(status[0])).nil?
+            end
+            can_remove.empty? || redis.zrem(set_key, can_remove)
+          end
         end
 
         # Get a status by UUID. Returns a Resque::Plugins::Status::Hash

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -251,6 +251,7 @@ class TestResquePluginsStatus < Test::Unit::TestCase
     context "invoking killall jobs to kill a range" do
       setup do
         @uuid1    = KillableJob.create(:num => 100)
+        sleep 1
         @uuid2    = KillableJob.create(:num => 100)
 
         Resque::Plugins::Status::Hash.killall(0,0) # only @uuid2 should be killed


### PR DESCRIPTION
when i set

```
Resque::Plugins::Status::Hash.expire_in = 60
```

and i create a job get uuid1 and do

```
loop { Resque::Plugins::Status::Hash.set(uuid1,"message") }
```

after 60 second i create another job,in resque-web statuses page i can't find uuid1's info but  status:uuid still exists in redis.
so i think _statuses uuid should not removed when expired but the status:uuid key-value exists.
