### PR TITLE
Adds per_page variable to statuses erb template since Resque 1.23.1+ depends on it.

### DIFF
--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -46,7 +46,7 @@
 </table>
 
 <% unless @statuses.empty? %>
-  <%= partial :next_more, :start => @start, :size => @size %>
+  <%= partial :next_more, :start => @start, :size => @size, :per_page => 20 %>
 <% end %>
 
 <%= status_poll(@start) %>


### PR DESCRIPTION
The statuses tab is broken in Resque 1.23.1 and higher because the next_more template added a variable, `per_page`. This pull request simply passes this value to the erb.
