### PR TITLE
Removes `extend Resque::Helpers`, adds compatibility shims.

### DIFF
--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -9,8 +9,6 @@ module Resque
       # creating/updating/retrieving status objects from Redis
       class Hash < ::Hash
 
-        extend Resque::Helpers
-
         # Create a status, generating a new UUID, passing the message to the status
         # Returns the UUID of the new status.
         def self.create(uuid, *messages)
@@ -188,6 +186,13 @@ module Resque
             !!self['#{name}']
           end
           EOT
+        end
+
+        # Proxy deprecated methods directly back to Resque itself.
+        class << self
+          [:redis, :encode, :decode].each do |method|
+            define_method(method) { |*args| Resque.send(method, *args) }
+          end
         end
 
         STATUSES = %w{queued working completed failed killed}.freeze


### PR DESCRIPTION
`Resque::Plugins::Status::Hash` uses `Resque::Helpers`; this PR replaces the methods it uses with compatibility shims.

I considered adding an extra test for this shimming specifically, but all the other test cases offer coverage it needs already. I can add in explicit test cases if you'd prefer.

(At the very least, this will stop the `Resque::Helpers will be gone with no replacement in Resque 2.0.0.` notice showing up in everyone's logs. See #89.)
