### PR TITLE
Fix exception when calling Hash.statuses with an empty database

### DIFF
--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -86,7 +86,7 @@ module Resque
         #   Resque::Plugins::Status::Hash.statuses(0, 20)
         def self.statuses(range_start = nil, range_end = nil)
           ids = status_ids(range_start, range_end)
-          mget(ids).compact
+          ids.any? ? mget(ids).compact : []
         end
 
         # Return the <tt>num</tt> most recent status/job UUIDs in reverse chronological order.

--- a/test/test_resque_plugins_status_hash.rb
+++ b/test/test_resque_plugins_status_hash.rb
@@ -189,6 +189,12 @@ class TestResquePluginsStatusHash < Test::Unit::TestCase
         assert_same_elements [@uuid_with_json, @uuid], statuses.collect {|s| s.uuid }
       end
 
+      should "return an empty array when no statuses are available" do
+        Resque.redis.flushall
+        statuses = Resque::Plugins::Status::Hash.statuses
+        assert_equal [], statuses
+      end
+
     end
 
     Resque::Plugins::Status::STATUSES.each do |status_code|


### PR DESCRIPTION
Fixes errors along the lines of

```
Redis::CommandError - ERR wrong number of arguments for 'mget' command:
```

As reported by  @nicholaihsu
