### PR TITLE
Support for delayed status

### DIFF
--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -35,12 +35,14 @@ module Resque
       STATUS_COMPLETED = 'completed'
       STATUS_FAILED = 'failed'
       STATUS_KILLED = 'killed'
+      STATUS_DELAYED = 'delayed'
       STATUSES = [
         STATUS_QUEUED,
         STATUS_WORKING,
         STATUS_COMPLETED,
         STATUS_FAILED,
-        STATUS_KILLED
+        STATUS_KILLED,
+        STATUS_DELAYED
       ].freeze
 
       autoload :Hash, 'resque/plugins/status/hash'
@@ -162,6 +164,9 @@ module Resque
         if status && status.failed?
           on_failure(status.message) if respond_to?(:on_failure)
           return
+        elsif status && status.delayed?
+          on_delayed(status.message) if respond_to?(:on_delayed)
+          return
         elsif status && !status.completed?
           completed
         end
@@ -225,6 +230,11 @@ module Resque
       # set the status to 'failed' passing along any additional messages
       def failed(*messages)
         set_status({'status' => STATUS_FAILED}, *messages)
+      end
+
+      # set the status to 'delayed' passing along any additional messages
+      def delayed(*messages)
+        set_status({'status' => STATUS_DELAYED}, *messages)
       end
 
       # set the status to 'completed' passing along any addional messages

--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -165,7 +165,7 @@ module Resque
           on_failure(status.message) if respond_to?(:on_failure)
           return
         elsif status && status.delayed?
-          on_delayed(status.message) if respond_to?(:on_delayed)
+          on_delayed if respond_to?(:on_delayed)
           return
         elsif status && !status.completed?
           completed

--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -70,6 +70,14 @@ module Resque
           end
         end
 
+        def self.clear_delayed(range_start = nil, range_end = nil)
+          status_ids(range_start, range_end).select do |id|
+            get(id).delayed?
+          end.each do |id|
+            remove(id)
+          end
+        end
+
         def self.remove(uuid)
           redis.del(status_key(uuid))
           redis.zrem(set_key, uuid)

--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -248,10 +248,10 @@ module Resque
           end
         end
 
-        # Can the job be killed? failed, completed, and killed jobs can't be
+        # Can the job be killed? failed, completed, delayed, and killed jobs can't be
         # killed, for obvious reasons
         def killable?
-          !failed? && !completed? && !killed?
+          !failed? && !completed? && !killed? && !delayed?
         end
 
         unless method_defined?(:to_json)

--- a/lib/resque/server/views/status_styles.erb
+++ b/lib/resque/server/views/status_styles.erb
@@ -79,6 +79,9 @@
   .status-progress-bar.status-killed {
     background: #B84F16;
   }
+  .status-progress-bar.status-delayed {
+    background: #B8B816;
+  }
   .status-completed {
     color:#61BF55;
   }
@@ -90,6 +93,9 @@
   }
   .status-killed {
     color: #B84F16;
+  }
+  .status-delayed {
+    color: #B8B816;
   }
   #main a.kill:link, #main a.kill:visited {
     color: #B84F16;

--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -11,6 +11,9 @@
 <form method="POST" action="<%= u(:statuses) %>/clear/failed" class='clear-failed'>
   <input type='submit' name='' value='Clear Failed Statuses' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
 </form>
+<form method="POST" action="<%= u(:statuses) %>/clear/delayed" class='clear-delayed'>
+  <input type='submit' name='' value='Clear Delayed Statuses' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+</form>
 <%end%>
 <p class='intro'>These are recent jobs created with the Resque::Plugins::Status class</p>
 <table>

--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -49,7 +49,7 @@
 </table>
 
 <% unless @statuses.empty? %>
-  <%= partial :next_more, :start => @start, :size => @size %>
+  <%= partial :next_more, :start => @start, :size => @size, :per_page => @per_page %>
 <% end %>
 
 <%= status_poll(@start) %>

--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -47,6 +47,11 @@ module Resque
         redirect u(:statuses)
       end
 
+      app.post '/statuses/clear/delayed' do
+        Resque::Plugins::Status::Hash.clear_delayed
+        redirect u(:statuses)
+      end
+
       app.get "/statuses.poll" do
         content_type "text/plain"
         @polling = true

--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -10,7 +10,8 @@ module Resque
 
       app.get '/statuses' do
         @start = params[:start].to_i
-        @end = @start + (params[:per_page] || 50)
+        @per_page = (params[:per_page] || 50).to_i
+        @end = @start + @per_page - 1
         @statuses = Resque::Plugins::Status::Hash.statuses(@start, @end)
         @size = @statuses.size
         status_view(:statuses)
@@ -57,7 +58,8 @@ module Resque
         @polling = true
 
         @start = params[:start].to_i
-        @end = @start + (params[:per_page] || 50)
+        @per_page = (params[:per_page] || 50).to_i
+        @end = @start + @per_page - 1
         @statuses = Resque::Plugins::Status::Hash.statuses(@start, @end)
         @size = @statuses.size
 

--- a/lib/resque/status_server.rb
+++ b/lib/resque/status_server.rb
@@ -13,7 +13,7 @@ module Resque
         @per_page = (params[:per_page] || 50).to_i
         @end = @start + @per_page - 1
         @statuses = Resque::Plugins::Status::Hash.statuses(@start, @end)
-        @size = @statuses.size
+        @size = Resque::Plugins::Status::Hash.status_ids.size
         status_view(:statuses)
       end
 
@@ -61,7 +61,7 @@ module Resque
         @per_page = (params[:per_page] || 50).to_i
         @end = @start + @per_page - 1
         @statuses = Resque::Plugins::Status::Hash.statuses(@start, @end)
-        @size = @statuses.size
+        @size = Resque::Plugins::Status::Hash.status_ids.size
 
         status_view(:statuses, {:layout => false})
       end

--- a/resque-status.gemspec
+++ b/resque-status.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "resque-status"
-  s.version = "0.4.3"
+  s.version = "0.4.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -319,6 +319,20 @@ class TestResquePluginsStatus < Test::Unit::TestCase
         end
       end
 
+      context "#delayed" do
+        setup do
+          @job.delayed("Later...")
+        end
+
+        should "set status" do
+          assert @job.status.delayed?
+        end
+
+        should "set message" do
+          assert_equal "Later...", @job.status.message
+        end
+      end
+
       context "#completed" do
         setup do
           @job.completed

--- a/test/test_resque_plugins_status_hash.rb
+++ b/test/test_resque_plugins_status_hash.rb
@@ -152,6 +152,23 @@ class TestResquePluginsStatusHash < Test::Unit::TestCase
       end
     end
 
+    context ".clear_delayed" do
+      setup do
+        @delayed_status_id = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid, {'status' => "delayed"})
+        @not_delayed_status_id = Resque::Plugins::Status::Hash.create(Resque::Plugins::Status::Hash.generate_uuid)
+        Resque::Plugins::Status::Hash.clear_delayed
+      end
+
+      should "clear delayed status" do
+        assert_nil Resque::Plugins::Status::Hash.get(@delayed_status_id)
+      end
+
+      should "not clear not-delayed status" do
+        status = Resque::Plugins::Status::Hash.get(@not_delayed_status_id)
+        assert status.is_a?(Resque::Plugins::Status::Hash)
+      end
+    end
+
     context ".remove" do
       setup do
         Resque::Plugins::Status::Hash.remove(@uuid)


### PR DESCRIPTION
I've created a new status called 'delayed' to indicate that the job has been rescheduled to run at a later time using resque-scheduler or some other external mechanism.  Setting the status itself doesn't actually perform the rescheduling, it just serves as a firm indicator that the job is delayed.  The on_delayed hook could be used to do the actual rescheduling if desired.