### PR TITLE
Updated read me

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -115,7 +115,7 @@ download by the user.
 
 A Status is actually just a hash, so inside a job you can do:
 
-    status['filename'] = '/myfilename'
+    set_status(filename: "myfilename")
 
 Also, all the status setting methods take any number of hash arguments. So you could do:
 


### PR DESCRIPTION
It's not passing back data using `status["xx"]` syntax as you mentioned at #66 . So why would it make sense to keep it on README? It's just wasting time. 