### PR TITLE
Truncating the name in the webview

### DIFF
--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -27,7 +27,7 @@
     <% @statuses.each do |status| %>
     <tr>
       <td><a href="<%= u(:statuses) %>/<%= status.uuid %>"><%= status.uuid %></a></td>
-      <td><%= status.name %></td>
+      <td><%= status.name.truncate(100) %></td>
       <td class="status status-<%= status.status %>"><%= status.status %></td>
       <td class="time"><%= status.time.strftime("%Y/%m/%d %H:%M:%S %z") %></td>
       <td class="progress">

--- a/lib/resque/server/views/statuses.erb
+++ b/lib/resque/server/views/statuses.erb
@@ -27,7 +27,7 @@
     <% @statuses.each do |status| %>
     <tr>
       <td><a href="<%= u(:statuses) %>/<%= status.uuid %>"><%= status.uuid %></a></td>
-      <td><%= status.name.truncate(100) %></td>
+      <td><%= (status.name||"").truncate(100) %></td>
       <td class="status status-<%= status.status %>"><%= status.status %></td>
       <td class="time"><%= status.time.strftime("%Y/%m/%d %H:%M:%S %z") %></td>
       <td class="progress">


### PR DESCRIPTION
Large json objects would fill up the screen with a wall of text. Truncating the name (json) on the index screen allows me to see all of my tasks at a glance.