### PR TITLE
Add status callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ doc
 test/dump.rdb
 bin/
 .bundle
+test/stdout

--- a/README.rdoc
+++ b/README.rdoc
@@ -147,6 +147,105 @@ Since Redis is RAM based, we probably don't want to keep these statuses around f
 and their related keys will expire in expire_in seconds from the last time theyre updated:
 
   Resque::Plugins::Status::Hash.expire_in = (60 * 60) # 1 hour
+
+=== Callbacks
+
+To avoid repeating code which should fire when common behavior happens, you can use
+the following callbacks:
+
+==== after_completed
+
+  class CompletedCallbackJob
+    include Resque::Plugins::Status
+
+    after_completed :report
+
+    def report msg
+      puts msg
+    end
+
+    def perform
+      self.completed "Our journey is at an end"
+    end
+  end
+
+Often used for a job which has worked successfully.
+
+==== after_killed
+
+  class KilledCallbackJob
+    include Resque::Plugins::Status
+
+    after_killed :report
+
+    def report
+      puts "Dramatic death scene goes here"
+    end
+
+    def perform
+      self.kill!
+    end
+  end
+
+Note that 'kill' does not log any messages, so your callback is simply a no-arg
+function.
+
+==== after_failed
+
+  class FailedCallbackJob
+    include Resque::Plugins::Status
+
+    after_failed :report
+
+    def report msg
+      puts msg
+    end
+
+    def perform
+      self.failed "Wow, so resque, such failed"
+    end
+  end
+
+Remember, the 'failed' callback will only work if you are in a situation where the
+worker is still working in some fashion. If the worker gets stuck, for example if
+it runs out of RAM, it won't be able to trigger this.
+
+==== after_tick
+
+  class AtCallbackJob
+    include Resque::Plugins::Status
+
+    # Remember, 'at' shares 'tick' callbacks
+    after_tick :report
+
+    def report msg
+      puts "This is my message: #{msg}"
+    end
+
+    def perform
+      at(1, 1, "report_message")
+    end
+  end
+
+  class TickCallbackJob
+    include Resque::Plugins::Status
+
+    after_tick :report
+
+    def report msg
+      puts "This is my tick message: #{msg}"
+    end
+
+    def perform
+      tick("tick_message")
+    end
+  end
+
+Note that, since 'at' calls 'tick' internally, any callbacks you define with after_tick
+will be shared by calls to 'at' as well. However, an 'at' callback is also passed
+the numeric progress bar data, i.e. `{'num' => 1, 'total' => 1}, 'some message'`,
+whereas 'tick' callbacks just get the message.
+
 === Testing
 
 Recent versions of Resque introduced `Resque.inline` which changes the behavior to 

--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -291,7 +291,7 @@ module Resque
         if self.class.killed_callbacks
           self.class.killed_callbacks.each do |callback_method|
             # The methods in the array are symbols, so use 'send'
-            self.send callback_method, *messages
+            self.send callback_method
           end
         end
         

--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -144,6 +144,13 @@ module Resque
         def scheduled(queue, klass, *args)
           self.enqueue_to(queue, self, *args)
         end
+        
+        # Append any desired callbacks to the callback chain
+        def after_tick(*method_symbols)
+          # Remember this will become a class variable
+          # The varargs have been splatted, so available as a plain old array now
+          @callback_methods = method_symbols
+        end
       end
 
       # Create a new instance with <tt>uuid</tt> and <tt>options</tt>

--- a/lib/resque/plugins/status.rb
+++ b/lib/resque/plugins/status.rb
@@ -56,6 +56,9 @@ module Resque
       end
 
       module ClassMethods
+        # Contains symbols of all the instance methods on the worker that the user
+        # wants to be called after each invokation of 'set_status'.
+        @@callback_methods = []
 
         # The default queue is :statused, this can be ovveridden in the specific job
         # class to put the jobs on a specific worker queue
@@ -149,7 +152,7 @@ module Resque
         def after_status(*method_symbols)
           # Remember this will become a class variable
           # The varargs have been splatted, so available as a plain old array now
-          @callback_methods = method_symbols
+          @@callback_methods << method_symbols
         end
       end
 
@@ -258,8 +261,9 @@ module Resque
         self.status = the_status
         
         # Now call the callbacks, if there are any
-        if @callback_methods
-          @callback_methods.each do |callback_method|
+        # remember the list is on the class, not the instance
+        if defined? @@callback_methods
+          @@callback_methods.each do |callback_method|
             # The methods in the array are actually symbols, so use 'send'
             self.send callback_method, the_status
           end  

--- a/test/redis-test.conf
+++ b/test/redis-test.conf
@@ -109,11 +109,6 @@ databases 16
 
 ############################### ADVANCED CONFIG ###############################
 
-# Glue small output buffers together in order to send small replies in a
-# single TCP packet. Uses a bit more CPU but most of the times it is a win
-# in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
-
 # Use object sharing. Can save a lot of memory if you have many common
 # string in your dataset, but performs lookups against the shared objects
 # pool so it uses more CPU and can be a bit slower. Usually it's a good

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -122,6 +122,20 @@ class AtCallbackJob
   end
 end
 
+class TickCallbackJob
+  include Resque::Plugins::Status
+
+  after_tick :report
+  
+  def report msg
+    puts "This is my tick message: #{msg}"
+  end
+
+  def perform    
+    tick("tick_message")
+  end
+end
+
 class KilledCallbackJob
   include Resque::Plugins::Status
 
@@ -147,5 +161,19 @@ class CompletedCallbackJob
 
   def perform    
     self.completed "Whether through good times or bad, our journey is at an end"
+  end
+end
+
+class FailedCallbackJob
+  include Resque::Plugins::Status
+
+  after_failed :report
+  
+  def report msg
+    puts msg
+  end
+
+  def perform    
+    self.failed "Wow, so resque, such failed"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -111,7 +111,7 @@ class TickCallbackJob
 
   include Resque::Plugins::Status
 
-  after_tick :report
+  after_status :report
   
   # Note, report is an instance method
   # so it can use the 'options' hash if needed

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -111,7 +111,7 @@ class TickCallbackJob
 
   include Resque::Plugins::Status
 
-  after_status :report
+  after_tick :report
   
   # Note, report is an instance method
   # so it can use the 'options' hash if needed
@@ -122,10 +122,8 @@ class TickCallbackJob
     puts "This is my message: #{msg}"
   end
 
-  def perform
-    msg = options['the_message']
-    
-    at(1, 1, msg)
+  def perform    
+    at(1, 1, "report_message")
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -106,3 +106,26 @@ class NeverQueuedJob
     # will never get called
   end
 end
+
+class TickCallbackJob
+
+  include Resque::Plugins::Status
+
+  after_tick :report
+  
+  # Note, report is an instance method
+  # so it can use the 'options' hash if needed
+  def report msg
+    # A somewhat trivial example, but in real systems
+    # this could be used to trigger Webhook callbacks,
+    # AMQP deliveries, etc. without repeating that code.
+    puts "This is my message: #{msg}"
+  end
+
+  def perform
+    msg = options['the_message']
+    
+    at(1, 1, msg)
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -107,23 +107,45 @@ class NeverQueuedJob
   end
 end
 
-class TickCallbackJob
-
+class AtCallbackJob
   include Resque::Plugins::Status
 
+  # Remember, 'at' shares 'tick' callbacks
   after_tick :report
   
-  # Note, report is an instance method
-  # so it can use the 'options' hash if needed
   def report msg
-    # A somewhat trivial example, but in real systems
-    # this could be used to trigger Webhook callbacks,
-    # AMQP deliveries, etc. without repeating that code.
     puts "This is my message: #{msg}"
   end
 
   def perform    
     at(1, 1, "report_message")
   end
+end
 
+class KilledCallbackJob
+  include Resque::Plugins::Status
+
+  after_killed :report
+  
+  def report msg
+    puts "Dramatic death scene goes here"
+  end
+
+  def perform    
+    self.kill!
+  end
+end
+
+class CompletedCallbackJob
+  include Resque::Plugins::Status
+
+  after_completed :report
+  
+  def report msg
+    puts msg
+  end
+
+  def perform    
+    self.completed "Whether through good times or bad, our journey is at an end"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -141,7 +141,7 @@ class KilledCallbackJob
 
   after_killed :report
   
-  def report msg
+  def report
     puts "Dramatic death scene goes here"
   end
 

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -379,7 +379,11 @@ class TestResquePluginsStatus < Test::Unit::TestCase
       should "call back on kill" do
         # Kill does not cause any messages.
         @job.expects(:report).once
-        @job.perform
+        
+        # Still expecting to see 'Killed' raised after the callback fires.
+        assert_raise Resque::Plugins::Status::Killed do
+          @job.perform
+        end
       end  
     end
     

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -351,11 +351,11 @@ class TestResquePluginsStatus < Test::Unit::TestCase
 
     context "#after_status" do
       setup do
-        @job = TickCallbackJob.new({the_message: "123"})
+        @job = TickCallbackJob.new("123")
       end
       
       should "call back on tick" do
-        @job.expects(:report)
+        @job.expects(:report).with({'num' => 1, 'total' => 1}, 'report_message')
         
         @job.perform
       end  

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -349,13 +349,13 @@ class TestResquePluginsStatus < Test::Unit::TestCase
 
     end
 
-    context "#tick_callback" do
+    context "#after_status" do
       setup do
         @job = TickCallbackJob.new({the_message: "123"})
       end
       
       should "call back on tick" do
-        @job.expects(:report).with("123").once
+        @job.expects(:report)
         
         @job.perform
       end  

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -349,6 +349,18 @@ class TestResquePluginsStatus < Test::Unit::TestCase
 
     end
 
+    context "#tick_callback" do
+      setup do
+        @job = TickCallbackJob.new({the_message: "123"})
+      end
+      
+      should "call back on tick" do
+        @job.should_receive(:report).with("123")
+        
+        @job.perform
+      end  
+    end
+
   end
 
 end

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -360,6 +360,16 @@ class TestResquePluginsStatus < Test::Unit::TestCase
       end  
     end
 
+    context "#after_tick" do
+      setup do
+        @job = TickCallbackJob.new("123")
+      end
+      
+      should "call back on tick" do
+        @job.expects(:report).with('tick_message')
+        @job.perform
+      end  
+    end
 
     context "#after_killed" do
       setup do
@@ -384,6 +394,16 @@ class TestResquePluginsStatus < Test::Unit::TestCase
       end  
     end
     
+    context "#after_failed" do
+      setup do
+        @job = FailedCallbackJob.new("123")
+      end
+      
+      should "call back on fail" do
+        @job.expects(:report).with("Wow, so resque, such failed")
+        @job.perform
+      end  
+    end
   end
 
 end

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -349,18 +349,41 @@ class TestResquePluginsStatus < Test::Unit::TestCase
 
     end
 
-    context "#after_status" do
+    context "#after_at" do
       setup do
-        @job = TickCallbackJob.new("123")
+        @job = AtCallbackJob.new("123")
       end
       
-      should "call back on tick" do
+      should "call back on at" do
         @job.expects(:report).with({'num' => 1, 'total' => 1}, 'report_message')
-        
         @job.perform
       end  
     end
 
+
+    context "#after_killed" do
+      setup do
+        @job = KilledCallbackJob.new("123")
+      end
+      
+      should "call back on kill" do
+        # Kill does not cause any messages.
+        @job.expects(:report).once
+        @job.perform
+      end  
+    end
+    
+    context "#after_completed" do
+      setup do
+        @job = CompletedCallbackJob.new("123")
+      end
+      
+      should "call back on complete" do
+        @job.expects(:report).with("Whether through good times or bad, our journey is at an end")
+        @job.perform
+      end  
+    end
+    
   end
 
 end

--- a/test/test_resque_plugins_status.rb
+++ b/test/test_resque_plugins_status.rb
@@ -355,7 +355,7 @@ class TestResquePluginsStatus < Test::Unit::TestCase
       end
       
       should "call back on tick" do
-        @job.should_receive(:report).with("123")
+        @job.expects(:report).with("123").once
         
         @job.perform
       end  


### PR DESCRIPTION
Adds callbacks for these events, together with unit tests:

- after_tick (also shared with 'at')
- after_completed
- after_killed
- after_failed

Also adds a description of how to use them in the README