### PR TITLE
a small improvement on the way clear_completed and clear_failed are

### DIFF
--- a/lib/resque/plugins/status/hash.rb
+++ b/lib/resque/plugins/status/hash.rb
@@ -56,17 +56,23 @@ module Resque
 
         def self.clear_completed(range_start = nil, range_end = nil)
           status_ids(range_start, range_end).select do |id|
-            get(id).completed?
-          end.each do |id|
-            remove(id)
+            if get(id).completed?
+              remove(id)
+              true
+            else
+              false
+            end
           end
         end
 
         def self.clear_failed(range_start = nil, range_end = nil)
           status_ids(range_start, range_end).select do |id|
-            get(id).failed?
-          end.each do |id|
-            remove(id)
+            if get(id).failed?
+              remove(id)
+              true
+            else
+              false
+            end
           end
         end
 

--- a/test/redis-test.conf
+++ b/test/redis-test.conf
@@ -109,11 +109,6 @@ databases 16
 
 ############################### ADVANCED CONFIG ###############################
 
-# Glue small output buffers together in order to send small replies in a
-# single TCP packet. Uses a bit more CPU but most of the times it is a win
-# in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
-
 # Use object sharing. Can save a lot of memory if you have many common
 # string in your dataset, but performs lookups against the shared objects
 # pool so it uses more CPU and can be a bit slower. Usually it's a good


### PR DESCRIPTION
When the status queue is too big, wait to clear_completed and clear_failed to check all items if they are completed/failed and them remove the items  takes too much time. This approach removes when encounters the completed?/failed? item and then keeps returning the hashs of removed items. 

And i've removed the glueoutputbuf from redis-test.conf since it doesn't work on redis >= 2.6